### PR TITLE
Add check for whether compiler supports -finline-limit

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,12 +105,24 @@ if test "x$GCC" = "xyes"; then
       # add '-finline-limit=...' only for GCC 3.x and 4.x:
       case `$CC -dumpversion 2>/dev/null` in
       # these --params are also in 3.4.6, but not in 3.3.6
-      4.*) CFLAGS="$CFLAGS -finline-limit=5000 --param large-function-growth=4900 --param inline-unit-growth=900" ;;
-      3.*) CFLAGS="$CFLAGS -finline-limit=5000" ;;
+      4.*) INLINE_CFLAGS="-finline-limit=5000 --param large-function-growth=4900 --param inline-unit-growth=900" ;;
+      3.*) INLINE_CFLAGS="-finline-limit=5000" ;;
       esac ;;
   esac
 fi
 changequote([,])dnl
+
+dnl Add -finiline-limit only if compiler supports it
+save_cflags="$CFLAGS"
+CFLAGS=$INLINE_CFLAGS
+AC_MSG_CHECKING([whether CC supports -finline-limit])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])],
+    [AC_MSG_RESULT([yes])]
+    [AM_CFLAGS=$INLINE_CFLAGS],
+    [AC_MSG_RESULT([no])]
+)
+CFLAGS="$save_cflags"
+AC_SUBST([AM_CFLAGS])
 
 AC_OUTPUT([
 Makefile


### PR DESCRIPTION
Hexter currently won't compile on OS X Yosemite, giving the error:

```
clang: error: unknown argument: '-finline-limit=5000'
```

This is because -finline-limit isn't supported clang 6. The pull request fixes this by testing whether the user's compiler supports -finline-limit. I don't know about other compilers, but it seems better to just test if the compiler on the host system supports the flag rather than a) have a conditional for every possible compiler permutation or b) have a conditional for the sytem like "Darwin" or similar
